### PR TITLE
More space in login message for line wrap

### DIFF
--- a/centeredUi/ThemeCenterBrand.css
+++ b/centeredUi/ThemeCenterBrand.css
@@ -136,7 +136,7 @@ body {
     font-family: "Segoe UI Webfont", -apple-system, "Helvetica Neue", "Lucida Grande", Roboto, Ebrima, "Nirmala UI", Gadugi, "Segoe Xbox Symbol", "Segoe UI Symbol", "Meiryo UI", "Khmer UI", Tunga, "Lao UI", Raavi, "Iskoola Pota", Latha, Leelawadee, "Microsoft YaHei UI", "Microsoft JhengHei UI", "Malgun Gothic", "Estrangelo Edessa", "Microsoft Himalaya", "Microsoft New Tai Lue", "Microsoft PhagsPa", "Microsoft Tai Le", "Microsoft Yi Baiti", "Mongolian Baiti", "MV Boli", "Myanmar Text", "Cambria Math";
     font-weight: 300;
     font-size: 1.2rem;
-    height: 28px;
+    height: 56px;
     line-height: 28px;
     margin-bottom: 16px;
     margin-left: -2px;


### PR DESCRIPTION
The item #loginMessage only allows single line messages.
In German the is a line wrap and the text would float above the user text input.
Doubled the height so line wrap is possible