### PR TITLE
Fix Overflow Issues when too many Claims Providers

### DIFF
--- a/centeredUi/ThemeCenterBrand.css
+++ b/centeredUi/ThemeCenterBrand.css
@@ -117,6 +117,10 @@ body {
     /* Add drop shadow */
     box-shadow: 0 2px 3px rgba(0,0,0,0.55);
     border: 1px solid rgba(0,0,0,0.4);
+
+    /* Allow Scrolling */
+    overflow-y: auto;
+    max-height: 80%;
 }
 
 #header {
@@ -708,6 +712,10 @@ h5, .tinyText {
         /* Add drop shadow */
         box-shadow: 0 0 0 rgba(0,0,0,0);
         border: 0px solid rgba(0,0,0,0);
+
+        /* Allow Scrolling */
+        overflow-y: initial;
+        max-height: initial;
     }
 
     #footer {

--- a/centeredUi/ThemeCenterBrandRTL.css
+++ b/centeredUi/ThemeCenterBrandRTL.css
@@ -107,6 +107,10 @@ body {
     /* Add drop shadow */
     box-shadow: 0 2px 3px rgba(0,0,0,0.55);
     border: 1px solid rgba(0,0,0,0.4);
+
+    /* Allow Scrolling */
+    overflow-y: auto;
+    max-height: 80%;
 }
 
 #header {
@@ -698,6 +702,10 @@ h5, .tinyText {
         /* Add drop shadow */
         box-shadow: 0 0 0 rgba(0,0,0,0);
         border: 0px solid rgba(0,0,0,0);
+
+        /* Allow Scrolling */
+        overflow-y: initial;
+        max-height: initial;
     }
 
     #footer {


### PR DESCRIPTION
When there are too many claims provider trusts, the desktop view cannot scroll to select the appropriate provider. See example here:

![image](https://user-images.githubusercontent.com/33401067/81513114-96037400-92eb-11ea-9b76-e2430c2a93c9.png)

The additional 4 lines of CSS allows for overflow to be enabled after the `#content` class has reached 80% of the display (only on desktop view, options are set back to initial on mobile).

Here is what it looks like now:

![image](https://user-images.githubusercontent.com/33401067/81513200-41142d80-92ec-11ea-9c32-8626d34c5b96.png)

These changes have been tested on Windows - Chrome, New Edge, Old Edge, Firefox, in additional to the "mobile" version developer tools on all of those.